### PR TITLE
feat: add comments consideration to resolve-issue functionality

### DIFF
--- a/bin/resolve-gh-issue
+++ b/bin/resolve-gh-issue
@@ -158,9 +158,21 @@ get_issue_details() {
     log_info "Getting issue details for #$issue_number..." >&2
     
     local issue_data
-    issue_data=$(gh issue view "$issue_number" --json title,body,labels)
+    issue_data=$(gh issue view "$issue_number" --json title,body,labels,comments)
     
-    echo "$issue_data"
+    # Filter comments to only include author and body fields, excluding minimized comments
+    local filtered_data
+    filtered_data=$(echo "$issue_data" | jq '{
+        title: .title,
+        body: .body,
+        labels: .labels,
+        comments: [.comments[] | select(.isMinimized == false) | {
+            author: .author.login,
+            body: .body
+        }]
+    }')
+    
+    echo "$filtered_data"
 }
 
 # Generate branch name using claude


### PR DESCRIPTION
Add comments field to GitHub issue data fetching in resolve-issue functionality.

## Changes
- Add comments field to GitHub issue data fetching
- Filter comments to only include author and body fields
- Exclude minimized comments from processing
- Maintain existing title, body, and labels functionality

Resolves #13

Generated with [Claude Code](https://claude.ai/code)