### PR TITLE
Change dependabot-auto-merge trigger from pull_request_target to pull_request

### DIFF
--- a/repository-template/.github/workflows/dependabot-auto-merge.yaml
+++ b/repository-template/.github/workflows/dependabot-auto-merge.yaml
@@ -1,7 +1,7 @@
 name: Dependabot Auto-Merge
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/repository-template/README.md
+++ b/repository-template/README.md
@@ -47,14 +47,13 @@ AI 自動化用の GitHub Personal Access Token を作成します。
 
 ### Dependabot 用の Secrets
 
-Dependabot が使用する secrets は、通常の Actions secrets とは別に設定が必要です。
+`dependabot-auto-merge.yaml` は `pull_request` イベントを使用するため、
+Dependabot が作成した PR では Dependabot secrets が参照されます。
+通常の Actions secrets とは別に設定が必要です。
 
 1. リポジトリの Settings > Secrets and variables > Dependabot
 2. 「New repository secret」をクリック
 3. `AI_USER_GH_TOKEN` を追加
-
-> **Important:** `dependabot-auto-merge.yaml` は `pull_request_target` イベントを使用するため、
-> Dependabot secrets ではなく通常の Actions secrets から `AI_USER_GH_TOKEN` を読み取ります。
 
 ## ワークフロー一覧
 


### PR DESCRIPTION
## Summary

Changed the `dependabot-auto-merge.yaml` workflow trigger from `pull_request_target` to `pull_request` event, which allows Dependabot secrets to be properly referenced in the workflow.

## Key Changes

- Updated workflow trigger event from `pull_request_target` to `pull_request`
- Updated README documentation to reflect that Dependabot secrets are now used (instead of regular Actions secrets)
- Removed outdated note about `pull_request_target` requiring regular Actions secrets

## Implementation Details

The `pull_request` event (compared to `pull_request_target`) runs in the context of the PR branch, which allows access to Dependabot secrets. This simplifies the secret management by using Dependabot-specific secrets consistently, eliminating the need to maintain separate regular Actions secrets for this workflow.

https://claude.ai/code/session_01NrvUYQeMog6z9nrXijg1jR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の自動マージ処理を改善し、より効率的な運用が可能になりました。

* **Documentation**
  * 依存関係管理ワークフローの設定手順をドキュメントに追加し、セットアップがより明確になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaakaito/env/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->